### PR TITLE
Fix encoding of titles and authors in database

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -13,7 +13,7 @@ services:
       - USER=user
       - PASS=${DOWNLOAD_PASS}
       - URL=https://aifm-music.dotan.de
-      - NUM_DOWNLOADS=50
+      - NUM_DOWNLOADS=88
     volumes:
       - audio-files:/audio
       - sql-files:/docker-entrypoint-initdb.d

--- a/k8s/downloader-job.yaml
+++ b/k8s/downloader-job.yaml
@@ -24,7 +24,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: NUM_DOWNLOADS
-              value: "50"
+              value: "88"
             - name: PASS
               valueFrom:
                 secretKeyRef:

--- a/server/database/downloader/download.py
+++ b/server/database/downloader/download.py
@@ -216,7 +216,8 @@ def main():
     print("Finished all downloads")
 
     # Write data
-    with open(ENTRYPOINT_DIR / SQL_FILE_2, "w") as f:
+    with open(ENTRYPOINT_DIR / SQL_FILE_2, "w", encoding="utf-8") as f:
+        f.write("SET NAMES utf8mb4;\n")
         if audio_entries:
             f.write("INSERT INTO audio_files (id, filename)\nVALUES\n")
             f.write(",\n".join(audio_entries) + ";\n\n")


### PR DESCRIPTION
Titles and authors written into the database incorrectly used latin1 encoding. 

Fixed by:
- writing `sql.data` in `downloader.py` with `encoding="utf-8"`
- adding `SET NAMES utf8mb4;` to `sql.data`

Also increased number of available songs to current maximum